### PR TITLE
Pin alpine to version 3.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.19
 
 LABEL version="2.0.0"
 LABEL name="kubectl"


### PR DESCRIPTION
- alpine 3.20 was released some hours ago. When you use that version, it is unable to install aws-cli. This is because aws-cli got disabled in Alpine 3.20 due to missing Python 3.12 compat.

See https://github.com/alpinelinux/docker-alpine/issues/396 for more details.